### PR TITLE
Remove "Akkreditierung"

### DIFF
--- a/2_inhaltliche_grundlagen/2_inhaltliche_grundlagen.md
+++ b/2_inhaltliche_grundlagen/2_inhaltliche_grundlagen.md
@@ -436,9 +436,9 @@ lizenziert unter [CC-BY-NC
 Die Form von Standards entspricht in der Regel einem formalisierten
 Dokument, das die korrekte Implementierung des jeweiligen Standards
 beschreibt. Bisweilen werden auch Möglichkeiten zum Testen der korrekten
-Implementierung sowie Möglichkeiten zur Akkreditierung durch die
-veröffentlichende Institution gegeben.[^4] Pawlowski (2001) stellt
-folgende Anforderungen an Standards auf [@pawlowskieevzecl2001, S. 90f]:
+Implementierung durch die veröffentlichende Institution gegeben.[^4] 
+Pawlowski (2001) stellt folgende Anforderungen an Standards auf 
+[@pawlowskieevzecl2001, S. 90f]:
 
 - Rekombinierbarkeit
 - Rekontextualisierung


### PR DESCRIPTION
Vorsicht mit dem Begriff "Akkreditierung"! In Deutschland darf nur die  Deutsche Akkreditierungsstelle GmbH (DAkkS, https://www.dakks.de/de/home.html) akkreditieren.

Der Begriff meint im Allgemeinen, dass ein Testlabor etwas nach bestimmten (von der Akkreditierungsbehörde festgelegten!) Standards und Normen prüfen kann und entsprechende Zertifikate ausstellen darf.

Bevor man hier Probleme mit den Begriffen kommt, schlage ich die Löschung des Teils mit der Akkreditierung vor. Der Begriff hat eine juristische Komponente und ich bin mir unsicher, ob das so wie es hier steht, einer Überprüfung standhält.